### PR TITLE
refactor: make auth service host configurable

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -11,3 +11,5 @@ data:
   USERS_DB_USER: "backend"
   USERS_DB_PASSWORD: $USERS_DB_PASSWORD
   USERS_DB_HOST: "dpg-cgno8m8rddl9mmvdaja0-a.oregon-postgres.render.com"
+  USERS_AUTH_HOST: auth-svc
+  USERS_TEST_IS_TESTING: "False"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -27,3 +27,63 @@ def test_when_environment_has_prometheus_port_9004_expect_9004():
 def test_when_environment_debug_log_level_expect_debug():
     cnf = to_config(AppConfig)
     assert cnf.log_level == "DEBUG"
+
+
+@patch.dict(environ, {"USERS_DB_DRIVER": "postgresql"}, clear=True)
+def test_when_environment_db_driver_expect_postgresql():
+    cnf = to_config(AppConfig)
+    assert cnf.db.driver == "postgresql"
+
+
+@patch.dict(environ, {"USERS_DB_PASSWORD": "secret"}, clear=True)
+def test_when_environment_db_password_expect_secret():
+    cnf = to_config(AppConfig)
+    assert cnf.db.password == "secret"
+
+
+@patch.dict(environ, {"USERS_DB_USER": "backend"}, clear=True)
+def test_when_environment_db_user_expect_backend():
+    cnf = to_config(AppConfig)
+    assert cnf.db.user == "backend"
+
+
+@patch.dict(environ, {"USERS_DB_HOST": "localhost"}, clear=True)
+def test_when_environment_db_host_expect_localhost():
+    cnf = to_config(AppConfig)
+    assert cnf.db.host == "localhost"
+
+
+@patch.dict(environ, {"USERS_DB_PORT": "5432"}, clear=True)
+def test_when_environment_db_port_expect_5432():
+    cnf = to_config(AppConfig)
+    assert cnf.db.port == 5432
+
+
+@patch.dict(environ, {"USERS_DB_DATABASE": "fiufit"}, clear=True)
+def test_when_environment_db_database_expect_fiufit():
+    cnf = to_config(AppConfig)
+    assert cnf.db.database == "fiufit"
+
+
+@patch.dict(environ, {"USERS_AUTH_HOST": "auth-svc"}, clear=True)
+def test_when_environment_auth_host_expect_auth_svc():
+    cnf = to_config(AppConfig)
+    assert cnf.auth.host == "auth-svc"
+
+
+@patch.dict(environ, {"USERS_TEST_IS_TESTING": "True"}, clear=True)
+def test_when_environment_is_testing_expect_true():
+    cnf = to_config(AppConfig)
+    assert cnf.test.is_testing
+
+
+@patch.dict(environ, {"USERS_TEST_USER_ID": "banana"}, clear=True)
+def test_when_environment_user_id_expect_banana():
+    cnf = to_config(AppConfig)
+    assert cnf.test.user_id == "banana"
+
+
+@patch.dict(environ, {"USERS_TEST_ROLE": "AwesomeRole"}, clear=True)
+def test_when_environment_role_expect_awesome_role():
+    cnf = to_config(AppConfig)
+    assert cnf.test.role == "AwesomeRole"

--- a/users/config.py
+++ b/users/config.py
@@ -20,4 +20,20 @@ class AppConfig:
         port = var(5432, converter=int)
         database = var("postgres")
 
+    @config
+    class AUTH:
+        """Authentication service configuration."""
+
+        host = var("auth-svc")
+
+    @config
+    class TEST:
+        """Test configurations."""
+
+        is_testing = var(True, converter=bool)
+        user_id = var("magicword")
+        role = var("admin")
+
     db = group(DB)  # type: ignore
+    auth = group(AUTH)  # type: ignore
+    test = group(TEST)  # type: ignore

--- a/users/main.py
+++ b/users/main.py
@@ -84,7 +84,7 @@ async def get_credentials(req):
             "role": os.environ["TEST_ROLE"],
         }
         return testing_token
-    url = "http://localhost:8082/auth/credentials"
+    url = f"http://{CONFIGURATION.auth.host}/auth/credentials"
     creds = await httpx.AsyncClient().get(url, headers=req.headers)
     return creds.json()['data']
 
@@ -93,7 +93,8 @@ async def get_token(role, user_id):
     """Return token with role and user_id passed by parameter."""
     if "TESTING" in os.environ:
         return {"data": "test_token"}
-    url = "http://localhost:8082/auth/token?role=" + role + "&id=" + user_id
+    url = f"http://{CONFIGURATION.auth.host}/auth/token?role=" + role +\
+        "&id=" + user_id
     token = await httpx.AsyncClient().get(url)
     return token.json()["data"]
 


### PR DESCRIPTION
Add configurations for testing variables, but could not make them work leaving them unused for when I have time to refactor.